### PR TITLE
Add setup script and update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+backend/venv/
+backend/.env
+frontend/node_modules/
+frontend/package-lock.json
+frontend/.env.local

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Integrasjon med **Finnhub** for sanntids markedsdata.
 ---
 
 ## 📦 Kom i gang lokalt
+Kjør først setup-scriptet som konfigurerer prosjektet:
+
+```bash
+bash scripts/setup.sh
+```
+
 
 ### Backend
 ```bash

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,2 @@
+VITE_SUPABASE_URL=https://your-supabase-url.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e
+
+# Create Python virtual environment if it doesn't exist
+if [ ! -d "backend/venv" ]; then
+    python3 -m venv backend/venv
+fi
+
+# Install backend dependencies
+backend/venv/bin/python -m pip install --upgrade pip
+backend/venv/bin/pip install -r backend/requirements.txt
+
+# Copy environment example if .env is missing
+if [ ! -f "backend/.env" ]; then
+    cp backend/.envExample backend/.env
+fi
+
+# Install frontend dependencies
+(cd frontend && npm install)
+
+# Copy frontend env example if needed
+if [ ! -f "frontend/.env.local" ]; then
+    cp frontend/.env.local.example frontend/.env.local
+fi
+


### PR DESCRIPTION
## Summary
- add script to bootstrap backend and frontend
- add a sample env file for the frontend
- ignore environment artifacts
- document usage of setup script in README

## Testing
- `bash scripts/setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_68471d1392988327917247c13437d961