### PR TITLE
Fix imports and add route import tests

### DIFF
--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,6 +1,7 @@
 from fastapi import Depends, HTTPException
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from jose import jwt, JWTError
+from supabase import create_client, Client
 import os
 
 JWT_SECRET = os.getenv("SUPABASE_JWT_SECRET")
@@ -17,3 +18,11 @@ def get_current_user(token: HTTPAuthorizationCredentials = Depends(auth_scheme))
         return user_id
     except JWTError:
         raise HTTPException(status_code=401, detail="Ugyldig token")
+
+
+def get_supabase_client() -> Client:
+    url = os.getenv("SUPABASE_URL")
+    key = os.getenv("SUPABASE_KEY")
+    if not url or not key:
+        raise HTTPException(status_code=500, detail="Supabase config missing")
+    return create_client(url, key)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routes import protected, transactions, holdings, stock_history, portfolio, cash
+from app.routes import protected, transactions, holdings, stock_history, portfolio
 import os
 from dotenv import load_dotenv
 
@@ -29,7 +29,6 @@ app.include_router(transactions.router)
 app.include_router(holdings.router)
 app.include_router(stock_history.router)
 app.include_router(portfolio.router)
-app.include_router(cash.router)
 
 # Helse-sjekk
 @app.get("/api/health")

--- a/backend/app/routes/holdings.py
+++ b/backend/app/routes/holdings.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends
-from app.deps import get_current_user
+from app.dependencies import get_current_user
 import os, psycopg2, psycopg2.extras
 import finnhub
 from collections import defaultdict

--- a/backend/app/routes/stock_history.py
+++ b/backend/app/routes/stock_history.py
@@ -1,6 +1,6 @@
 # app/routes/stock_history.py
 from fastapi import APIRouter, Depends, HTTPException
-from app.auth import verify_token
+from app.dependencies import get_current_user
 import os
 from datetime import datetime, timedelta
 import httpx
@@ -8,7 +8,7 @@ import httpx
 router = APIRouter()
 
 @router.get("/api/stock-history/{ticker}")
-async def get_stock_history(ticker: str, user=Depends(verify_token)):
+async def get_stock_history(ticker: str, user_id: str = Depends(get_current_user)):
     API_KEY = os.getenv("FINNHUB_API_KEY")
     if not API_KEY:
         raise HTTPException(status_code=500, detail="Finnhub API-nøkkel mangler.")

--- a/backend/app/routes/transactions.py
+++ b/backend/app/routes/transactions.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException
-from app.deps import get_current_user
+from app.dependencies import get_current_user
 from app.models import TransactionCreate, Transaction
 from typing import List
 import os

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,82 @@
+import importlib
+import os
+import sys
+import types
+
+# Ensure backend directory is on path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "backend"))
+
+
+def stub_modules(monkeypatch):
+    # finnhub stub
+    finnhub = types.ModuleType("finnhub")
+    class Client:
+        def __init__(self, api_key=None):
+            pass
+        def quote(self, symbol):
+            return {"c": 0}
+    finnhub.Client = Client
+    monkeypatch.setitem(sys.modules, "finnhub", finnhub)
+
+    # psycopg2 stub
+    psycopg2 = types.ModuleType("psycopg2")
+    psycopg2.connect = lambda *a, **k: None
+    extras = types.ModuleType("psycopg2.extras")
+    extras.RealDictCursor = object
+    psycopg2.extras = extras
+    monkeypatch.setitem(sys.modules, "psycopg2", psycopg2)
+    monkeypatch.setitem(sys.modules, "psycopg2.extras", extras)
+
+    # supabase stub
+    supabase = types.ModuleType("supabase")
+    class SupabaseClient:
+        pass
+    def create_client(url, key):
+        return SupabaseClient()
+    supabase.Client = SupabaseClient
+    supabase.create_client = create_client
+    monkeypatch.setitem(sys.modules, "supabase", supabase)
+
+    # jose stub
+    jose = types.ModuleType("jose")
+    jwt = types.ModuleType("jose.jwt")
+    jwt.decode = lambda *a, **k: {"sub": "user"}
+    jose.jwt = jwt
+    jose.JWTError = Exception
+    monkeypatch.setitem(sys.modules, "jose", jose)
+    monkeypatch.setitem(sys.modules, "jose.jwt", jwt)
+
+    # httpx stub
+    httpx = types.ModuleType("httpx")
+    class AsyncClient:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+        async def get(self, url):
+            class Res:
+                status_code = 200
+                def json(self):
+                    return {"s": "ok", "c": [], "t": []}
+            return Res()
+    httpx.AsyncClient = AsyncClient
+    monkeypatch.setitem(sys.modules, "httpx", httpx)
+
+    # dotenv stub
+    dotenv = types.ModuleType("dotenv")
+    dotenv.load_dotenv = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "dotenv", dotenv)
+
+
+def test_all_routes_import(monkeypatch):
+    stub_modules(monkeypatch)
+    modules = [
+        "app.routes.holdings",
+        "app.routes.transactions",
+        "app.routes.stock_history",
+        "app.routes.protected",
+        "app.routes.portfolio",
+        "app.main",
+    ]
+    for mod in modules:
+        importlib.import_module(mod)


### PR DESCRIPTION
## Summary
- fix `get_current_user` imports in transaction and holdings routes
- remove unused `cash` route from app initialization
- use `get_current_user` in stock history route
- add missing `get_supabase_client` helper
- add tests to ensure route modules import without errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684721226cac8327b0424e85b283733e