### PR TITLE
Replace user.getSession with supabase call

### DIFF
--- a/frontend/src/pages/CashPage.jsx
+++ b/frontend/src/pages/CashPage.jsx
@@ -1,6 +1,7 @@
 import { useAuth } from '../context/AuthContext';
 import { useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
+import { supabase } from '../lib/supabaseClient';
 
 export default function CashPage() {
   const { user } = useAuth();
@@ -9,7 +10,7 @@ export default function CashPage() {
 
   useEffect(() => {
     const fetchCash = async () => {
-      const { data: sessionData } = await user?.getSession?.();
+      const { data: sessionData } = await supabase.auth.getSession();
       const token = sessionData?.session?.access_token;
 
       const res = await fetch('http://localhost:8000/api/cash', {
@@ -25,7 +26,7 @@ export default function CashPage() {
   }, [user]);
 
   const handleSave = async () => {
-    const { data: sessionData } = await user?.getSession?.();
+    const { data: sessionData } = await supabase.auth.getSession();
     const token = sessionData?.session?.access_token;
 
     const res = await fetch('http://localhost:8000/api/cash', {

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useAuth } from '../context/AuthContext';
 import { Pie } from 'react-chartjs-2';
+import { supabase } from '../lib/supabaseClient';
 import {
   Chart as ChartJS,
   ArcElement,
@@ -17,7 +18,7 @@ export default function Dashboard() {
 
   useEffect(() => {
     const fetchOverview = async () => {
-      const { data: sessionData } = await user?.getSession?.();
+      const { data: sessionData } = await supabase.auth.getSession();
       const token = sessionData?.session?.access_token;
 
       try {

--- a/frontend/src/pages/HoldingsPage.jsx
+++ b/frontend/src/pages/HoldingsPage.jsx
@@ -1,6 +1,7 @@
 // HoldingsPage.jsx
 import { useAuth } from '../context/AuthContext';
 import { useEffect, useState } from 'react';
+import { supabase } from '../lib/supabaseClient';
 import { useNavigate } from 'react-router-dom';
 
 export default function HoldingsPage() {
@@ -10,7 +11,7 @@ export default function HoldingsPage() {
 
   useEffect(() => {
     const fetchHoldings = async () => {
-      const { data: sessionData } = await user?.getSession?.();
+      const { data: sessionData } = await supabase.auth.getSession();
       const token = sessionData?.session?.access_token;
 
       const res = await fetch('http://localhost:8000/api/holdings', {

--- a/frontend/src/pages/StockDetail.jsx
+++ b/frontend/src/pages/StockDetail.jsx
@@ -2,6 +2,7 @@ import { useParams } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { useEffect, useState } from 'react';
 import StockChart from '../components/StockChart';
+import { supabase } from '../lib/supabaseClient';
 
 export default function StockDetail() {
   const { ticker } = useParams();
@@ -11,7 +12,7 @@ export default function StockDetail() {
 
   useEffect(() => {
     const fetchData = async () => {
-      const { data: sessionData } = await user?.getSession?.();
+      const { data: sessionData } = await supabase.auth.getSession();
       const token = sessionData?.session?.access_token;
 
       const resStock = await fetch(`http://localhost:8000/api/holdings/${ticker}`, {

--- a/frontend/src/pages/TransactionPage.jsx
+++ b/frontend/src/pages/TransactionPage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useAuth } from '../context/AuthContext';
 import TransactionModal from '../components/TransactionModal';
 import toast from 'react-hot-toast';
+import { supabase } from '../lib/supabaseClient';
 
 export default function TransactionPage() {
   const { user } = useAuth();
@@ -12,7 +13,7 @@ export default function TransactionPage() {
 
   useEffect(() => {
     const fetchTransactions = async () => {
-      const { data: sessionData } = await user?.getSession?.();
+      const { data: sessionData } = await supabase.auth.getSession();
       const token = sessionData?.session?.access_token;
 
       try {
@@ -32,7 +33,7 @@ export default function TransactionPage() {
   }, [user]);
 
   const handleSave = async (tx) => {
-    const { data: sessionData } = await user?.getSession?.();
+    const { data: sessionData } = await supabase.auth.getSession();
     const token = sessionData?.session?.access_token;
 
     const res = await fetch('http://localhost:8000/api/transactions', {
@@ -56,7 +57,7 @@ export default function TransactionPage() {
   const handleDelete = async (id) => {
     if (!confirm('Er du sikker på at du vil slette denne transaksjonen?')) return;
 
-    const { data: sessionData } = await user?.getSession?.();
+    const { data: sessionData } = await supabase.auth.getSession();
     const token = sessionData?.session?.access_token;
 
     const res = await fetch(`http://localhost:8000/api/transactions/${id}`, {
@@ -73,7 +74,7 @@ export default function TransactionPage() {
   };
 
   const handleUpdate = async (updatedTx) => {
-    const { data: sessionData } = await user?.getSession?.();
+    const { data: sessionData } = await supabase.auth.getSession();
     const token = sessionData?.session?.access_token;
 
     const res = await fetch(`http://localhost:8000/api/transactions/${updatedTx.id}`, {


### PR DESCRIPTION
## Summary
- standardize session retrieval across pages using `supabase.auth.getSession()`
- add missing `supabase` imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685068719e9c83278f82d32c747a505b