### PR TITLE
Fix trade type normalization

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 from typing import Optional
 from datetime import datetime
 
@@ -8,6 +8,10 @@ class TransactionCreate(BaseModel):
     shares: float
     price: float
     trade_date: Optional[datetime] = None
+
+    @validator("trade_type")
+    def uppercase_trade_type(cls, v: str) -> str:
+        return v.upper()
 
 class Transaction(TransactionCreate):
     id: str

--- a/frontend/src/components/TransactionModal.jsx
+++ b/frontend/src/components/TransactionModal.jsx
@@ -12,7 +12,8 @@ export default function TransactionModal({ isOpen, onClose, onSave, transaction 
   );
 
   useEffect(() => {
-    if (transaction) setForm(transaction);
+    if (transaction)
+      setForm({ ...transaction, trade_type: transaction.trade_type.toLowerCase() });
   }, [transaction]);
 
   const handleChange = (e) => {
@@ -21,7 +22,7 @@ export default function TransactionModal({ isOpen, onClose, onSave, transaction 
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    onSave(form);
+    onSave({ ...form, trade_type: form.trade_type.toUpperCase() });
     onClose();
   };
 

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -1,0 +1,15 @@
+from tests.test_imports import stub_modules
+import os, sys
+import types
+import importlib
+
+# ensure backend directory is on path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "backend"))
+
+from app.models import TransactionCreate
+
+def test_trade_type_normalization(monkeypatch):
+    stub_modules(monkeypatch)
+    tx = TransactionCreate(ticker="AAPL", trade_type="buy", shares=1, price=1.0)
+    assert tx.trade_type == "BUY"
+


### PR DESCRIPTION
## Summary
- normalize trade_type in frontend modal before submit
- ensure backend TransactionCreate uppercases trade_type
- add regression test for normalization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68506b67c2e88327a1a69d5a559e01f7