### PR TITLE
Add configurable API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ npm install
 
 ###Konfigurer .env.local
 cp .env.local.example .env.local
-# Rediger filen og legg inn dine egne verdier
+# Rediger filen og legg inn dine egne verdier, f.eks.:
+# VITE_SUPABASE_URL=...
+# VITE_SUPABASE_ANON_KEY=...
+# VITE_API_URL=http://localhost:8000
 
 ###Start frontend:
 npm run dev

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,2 +1,3 @@
 VITE_SUPABASE_URL=https://your-supabase-url.supabase.co
 VITE_SUPABASE_ANON_KEY=your-anon-key
+VITE_API_URL=http://localhost:8000

--- a/frontend/src/components/StockChart.jsx
+++ b/frontend/src/components/StockChart.jsx
@@ -17,7 +17,7 @@ export default function StockChart({ ticker }) {
 
   useEffect(() => {
     const fetchChart = async () => {
-      const res = await fetch(`http://localhost:8000/api/stock-history/${ticker}`);
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/api/stock-history/${ticker}`);
       const data = await res.json();
 
       const labels = data.map(item => item.date);

--- a/frontend/src/pages/CashPage.jsx
+++ b/frontend/src/pages/CashPage.jsx
@@ -13,7 +13,7 @@ export default function CashPage() {
       const { data: sessionData } = await supabase.auth.getSession();
       const token = sessionData?.session?.access_token;
 
-      const res = await fetch('http://localhost:8000/api/cash', {
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/api/cash`, {
         headers: { Authorization: `Bearer ${token}` },
       });
 
@@ -29,7 +29,7 @@ export default function CashPage() {
     const { data: sessionData } = await supabase.auth.getSession();
     const token = sessionData?.session?.access_token;
 
-    const res = await fetch('http://localhost:8000/api/cash', {
+    const res = await fetch(`${import.meta.env.VITE_API_URL}/api/cash`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -22,7 +22,7 @@ export default function Dashboard() {
       const token = sessionData?.session?.access_token;
 
       try {
-        const res = await fetch('http://localhost:8000/api/portfolio-overview', {
+        const res = await fetch(`${import.meta.env.VITE_API_URL}/api/portfolio-overview`, {
           headers: { Authorization: `Bearer ${token}` },
         });
         const data = await res.json();

--- a/frontend/src/pages/HoldingsPage.jsx
+++ b/frontend/src/pages/HoldingsPage.jsx
@@ -14,7 +14,7 @@ export default function HoldingsPage() {
       const { data: sessionData } = await supabase.auth.getSession();
       const token = sessionData?.session?.access_token;
 
-      const res = await fetch('http://localhost:8000/api/holdings', {
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/api/holdings`, {
         headers: { Authorization: `Bearer ${token}` },
       });
 

--- a/frontend/src/pages/StockDetail.jsx
+++ b/frontend/src/pages/StockDetail.jsx
@@ -16,7 +16,7 @@ export default function StockDetail() {
       const token = sessionData?.session?.access_token;
 
       // Fetch all holdings and find the one matching this ticker
-      const resHoldings = await fetch('http://localhost:8000/api/holdings', {
+      const resHoldings = await fetch(`${import.meta.env.VITE_API_URL}/api/holdings`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       const holdingsData = await resHoldings.json();
@@ -26,7 +26,7 @@ export default function StockDetail() {
         ) || null;
       setStock(match);
 
-      const resTx = await fetch('http://localhost:8000/api/transactions', {
+      const resTx = await fetch(`${import.meta.env.VITE_API_URL}/api/transactions`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       const allTx = await resTx.json();

--- a/frontend/src/pages/TransactionPage.jsx
+++ b/frontend/src/pages/TransactionPage.jsx
@@ -17,7 +17,7 @@ export default function TransactionPage() {
       const token = sessionData?.session?.access_token;
 
       try {
-        const res = await fetch('http://localhost:8000/api/transactions', {
+        const res = await fetch(`${import.meta.env.VITE_API_URL}/api/transactions`, {
           headers: { Authorization: `Bearer ${token}` },
         });
         const data = await res.json();
@@ -36,7 +36,7 @@ export default function TransactionPage() {
     const { data: sessionData } = await supabase.auth.getSession();
     const token = sessionData?.session?.access_token;
 
-    const res = await fetch('http://localhost:8000/api/transactions', {
+    const res = await fetch(`${import.meta.env.VITE_API_URL}/api/transactions`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -60,7 +60,7 @@ export default function TransactionPage() {
     const { data: sessionData } = await supabase.auth.getSession();
     const token = sessionData?.session?.access_token;
 
-    const res = await fetch(`http://localhost:8000/api/transactions/${id}`, {
+    const res = await fetch(`${import.meta.env.VITE_API_URL}/api/transactions/${id}`, {
       method: 'DELETE',
       headers: { Authorization: `Bearer ${token}` },
     });
@@ -77,7 +77,7 @@ export default function TransactionPage() {
     const { data: sessionData } = await supabase.auth.getSession();
     const token = sessionData?.session?.access_token;
 
-    const res = await fetch(`http://localhost:8000/api/transactions/${updatedTx.id}`, {
+    const res = await fetch(`${import.meta.env.VITE_API_URL}/api/transactions/${updatedTx.id}`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- add `VITE_API_URL` in `.env.local.example`
- use the new env variable for all API calls in the React frontend
- document the variable in `README`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68506c9f1f4483279600f3bc52d0f679